### PR TITLE
Fix sprite ground station compilation with Clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@
 *.out
 *.app
 
+*.pyc
 top_block.py

--- a/gr-sprite/lib/correlator_cf_impl.cc
+++ b/gr-sprite/lib/correlator_cf_impl.cc
@@ -119,7 +119,7 @@ namespace gr {
       
       for(int k = 0; k < SPRITE_PRN_LENGTH; k++)
       {
-        baseBand[k] = iBB[k]*cos(M_PI/2*k) + 1i*qBB[k]*sin(M_PI/2*k);
+        baseBand[k] = iBB[k]*cos(M_PI/2*k) + std::complex<double>{0, qBB[k]*sin(M_PI/2*k)};
       }
     }
 


### PR DESCRIPTION
Clang does not like the non-standard complex literal.

While here, add *.pyc to gitignore.